### PR TITLE
removing force unwrapping on TimeZone

### DIFF
--- a/CountdownLabel/CountdownLabel.swift
+++ b/CountdownLabel/CountdownLabel.swift
@@ -33,7 +33,7 @@ public class CountdownLabel: LTMorphingLabel {
     public var dateFormatter: DateFormatter {
         let df = DateFormatter()
         df.locale = Locale(identifier: "en_US_POSIX")
-        df.timeZone = NSTimeZone(name: "GMT") as TimeZone!
+        df.timeZone = NSTimeZone(name: "GMT") as TimeZone?
         df.dateFormat = timeFormat
         return df
     }


### PR DESCRIPTION
Fixing complier warning “Using '!' is not allowed here; perhaps '?' was intended?”